### PR TITLE
Align UI scaling with normalizer

### DIFF
--- a/app/src/main/java/com/example/scribbledash/features/drawscreen/components/ScaleCanvasImage.kt
+++ b/app/src/main/java/com/example/scribbledash/features/drawscreen/components/ScaleCanvasImage.kt
@@ -62,9 +62,10 @@ fun scaleImage(
 
     Log.d(TAG, "Scale calculations: scaleX=$scaleX, scaleY=$scaleY, final scale=$scale")
 
-    // Center offsets
-    val dx = (canvasW - drawingWidth * scale) / 2f - box.left * scale
-    val dy = (canvasH - drawingHeight * scale) / 2f - box.top * scale
+    // Translate drawing so its top-left corner aligns with the origin
+    // to mirror PathNormalizer behavior
+    val dx = -box.left * scale
+    val dy = -box.top * scale
 
     Log.d(TAG, "Offset calculations: dx=$dx, dy=$dy")
 


### PR DESCRIPTION
## Summary
- ensure canvas scaling uses origin-based translation rather than centering

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a25dfd1c83288d18670e9c45061a