### PR TITLE
Add shared bounds utility

### DIFF
--- a/app/src/main/java/com/example/scribbledash/features/difficultyscreen/domain/drawing/utils/BoundsCalculator.kt
+++ b/app/src/main/java/com/example/scribbledash/features/difficultyscreen/domain/drawing/utils/BoundsCalculator.kt
@@ -1,0 +1,40 @@
+package com.example.scribbledash.features.utils
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+
+/** Utility to compute bounding rectangles for a collection of points. */
+object BoundsCalculator {
+    /**
+     * Calculates the bounding [Rect] surrounding [points].
+     *
+     * @param points list of points to bound
+     * @param paddingPercent optional extra padding applied on all sides
+     * @return bounding [Rect] with the requested padding
+     */
+    fun calculateBounds(points: List<Offset>, paddingPercent: Float = 0f): Rect {
+        if (points.isEmpty()) {
+            val base = 1f
+            val padX = base * paddingPercent
+            val padY = base * paddingPercent
+            return Rect(-padX, -padY, base + padX, base + padY)
+        }
+
+        val minX = points.minOfOrNull { it.x } ?: 0f
+        val maxX = points.maxOfOrNull { it.x } ?: (minX + 1f)
+        val minY = points.minOfOrNull { it.y } ?: 0f
+        val maxY = points.maxOfOrNull { it.y } ?: (minY + 1f)
+        val width = (maxX - minX).takeIf { it > 0f } ?: 1f
+        val height = (maxY - minY).takeIf { it > 0f } ?: 1f
+
+        val paddingX = width * paddingPercent
+        val paddingY = height * paddingPercent
+
+        return Rect(
+            minX - paddingX,
+            minY - paddingY,
+            minX + width + paddingX,
+            minY + height + paddingY
+        )
+    }
+}

--- a/app/src/main/java/com/example/scribbledash/features/drawscreen/components/ScaleCanvasImage.kt
+++ b/app/src/main/java/com/example/scribbledash/features/drawscreen/components/ScaleCanvasImage.kt
@@ -3,6 +3,7 @@ package com.example.scribbledash.features.drawscreen.components
 import android.util.Log
 import androidx.compose.ui.geometry.Rect
 import com.example.scribbledash.features.drawscreen.presentation.model.StrokeData
+import com.example.scribbledash.features.utils.BoundsCalculator
 
 private const val TAG = "ScaleCanvasImage"
 
@@ -40,15 +41,9 @@ fun scaleImage(
             Log.w(TAG, "scaleImage: No points found to create bounding box")
         }
 
-        val minX = allPoints.minOfOrNull { it.x } ?: 0f
-        val maxX = allPoints.maxOfOrNull { it.x } ?: (minX + 1f)
-        val minY = allPoints.minOfOrNull { it.y } ?: 0f
-        val maxY = allPoints.maxOfOrNull { it.y } ?: (minY + 1f)
-        val width = (maxX - minX).takeIf { it > 0f } ?: 1f
-        val height = (maxY - minY).takeIf { it > 0f } ?: 1f
-
-        Log.d(TAG, "Calculated bounds: minX=$minX, maxX=$maxX, minY=$minY, maxY=$maxY, width=$width, height=$height")
-        Rect(minX, minY, minX + width, minY + height)
+        val rect = BoundsCalculator.calculateBounds(allPoints)
+        Log.d(TAG, "Calculated bounds: $rect")
+        rect
     }
 
     Log.d(TAG, "Using bounding box: $box (width=${box.width}, height=${box.height})")

--- a/app/src/main/java/com/example/scribbledash/features/drawscreen/presentation/DrawScreenResult.kt
+++ b/app/src/main/java/com/example/scribbledash/features/drawscreen/presentation/DrawScreenResult.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.foundation.layout.*
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.platform.LocalDensity
+import com.example.scribbledash.features.utils.BoundsCalculator
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -129,23 +130,7 @@ fun DrawScreenResult(
                         if (userPaths.isEmpty()) null
                         else {
                             val allPoints = userPaths.flatMap { it.points }
-                            val minX = allPoints.minOfOrNull { it.x } ?: 0f
-                            val maxX = allPoints.maxOfOrNull { it.x } ?: 0f
-                            val minY = allPoints.minOfOrNull { it.y } ?: 0f
-                            val maxY = allPoints.maxOfOrNull { it.y } ?: 0f
-
-                            // Add 10% padding on all sides
-                            val width = maxX - minX
-                            val height = maxY - minY
-                            val paddingX = width * 0.1f
-                            val paddingY = height * 0.1f
-
-                            Rect(
-                                minX - paddingX,
-                                minY - paddingY,
-                                maxX + paddingX,
-                                maxY + paddingY
-                            )
+                            BoundsCalculator.calculateBounds(allPoints, 0.1f)
                         }
                     }
 


### PR DESCRIPTION
## Summary
- implement `BoundsCalculator` to compute Offset bounding rects
- update `scaleImage` to use `BoundsCalculator`
- refactor `DrawScreenResult` to use the shared util for padding

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a91986c08328bcf6bc8d80ff3523