### PR TITLE
Refactor path smoothing into shared utility

### DIFF
--- a/app/src/main/java/com/example/scribbledash/features/difficultyscreen/domain/drawing/usecase/Comparator.kt
+++ b/app/src/main/java/com/example/scribbledash/features/difficultyscreen/domain/drawing/usecase/Comparator.kt
@@ -11,6 +11,7 @@ import com.example.scribbledash.features.utils.CoverageCalculator
 import com.example.scribbledash.features.utils.PathNormalizer
 import com.example.scribbledash.features.utils.PixelComparator
 import com.example.scribbledash.features.utils.StrokeWidthScaler
+import com.example.scribbledash.features.utils.DrawingUtils
 
 object Comparator : DrawingComparer {
     private const val CANVAS_SIZE_PX = 512
@@ -93,33 +94,7 @@ object Comparator : DrawingComparer {
      * mirroring your Compose createSmoothPath() logic.
      */
     private fun offsetsToAndroidPathSmooth(points: List<Offset>): AndroidPath {
-        val path = AndroidPath()
-        if (points.isEmpty()) return path
-
-        if (points.size == 1) {
-            path.moveTo(points[0].x, points[0].y)
-            path.lineTo(points[0].x, points[0].y + 0.1f)
-            return path
-        }
-
-        path.moveTo(points[0].x, points[0].y)
-        if (points.size == 2) {
-            path.lineTo(points[1].x, points[1].y)
-        } else {
-            for (i in 1 until points.size) {
-                if (i < points.size - 1) {
-                    val xc = (points[i].x + points[i + 1].x) / 2f
-                    val yc = (points[i].y + points[i + 1].y) / 2f
-                    path.quadraticBezierTo(
-                        points[i].x, points[i].y,  // control point
-                        xc, yc                      // end point
-                    )
-                } else {
-                    path.lineTo(points[i].x, points[i].y)
-                }
-            }
-        }
-        return path
+        return DrawingUtils.smoothPath(points).asAndroidPath()
     }
 }
 

--- a/app/src/main/java/com/example/scribbledash/features/difficultyscreen/domain/drawing/utils/DrawingUtils.kt
+++ b/app/src/main/java/com/example/scribbledash/features/difficultyscreen/domain/drawing/utils/DrawingUtils.kt
@@ -1,0 +1,47 @@
+package com.example.scribbledash.features.utils
+
+import android.util.Log
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Path
+
+private const val TAG = "DrawingUtils"
+
+/**
+ * Utility functions related to drawing paths.
+ */
+object DrawingUtils {
+    /**
+     * Create a smooth [Path] through the given [points] using quadratic Bézier curves.
+     */
+    fun smoothPath(points: List<Offset>): Path {
+        val path = Path()
+        if (points.isEmpty()) {
+            Log.d(TAG, "smoothPath: Empty points list")
+            return path
+        }
+        if (points.size == 1) {
+            Log.d(TAG, "smoothPath: Single point, creating minimal line")
+            path.moveTo(points[0].x, points[0].y)
+            path.lineTo(points[0].x, points[0].y + 0.1f)
+            return path
+        }
+
+        path.moveTo(points[0].x, points[0].y)
+        if (points.size == 2) {
+            Log.d(TAG, "smoothPath: Two points, creating direct line")
+            path.lineTo(points[1].x, points[1].y)
+        } else {
+            Log.v(TAG, "smoothPath: ${points.size} points, creating smooth path with bezier curves")
+            for (i in 1 until points.size) {
+                if (i < points.size - 1) {
+                    val xc = (points[i].x + points[i + 1].x) / 2f
+                    val yc = (points[i].y + points[i + 1].y) / 2f
+                    path.quadraticBezierTo(points[i].x, points[i].y, xc, yc)
+                } else {
+                    path.lineTo(points[i].x, points[i].y)
+                }
+            }
+        }
+        return path
+    }
+}

--- a/app/src/main/java/com/example/scribbledash/features/drawscreen/components/DrawingCanvas.kt
+++ b/app/src/main/java/com/example/scribbledash/features/drawscreen/components/DrawingCanvas.kt
@@ -26,6 +26,7 @@ import com.example.scribbledash.features.drawscreen.presentation.model.StrokeDat
 import android.util.Log
 import androidx.compose.foundation.layout.*
 import com.example.scribbledash.features.drawscreen.components.scaleImage
+import com.example.scribbledash.features.utils.DrawingUtils
 import kotlin.math.min
 
 private const val TAG = "DrawingCanvas"
@@ -171,34 +172,4 @@ fun DrawingCanvas(
 /**
  * Creates a smooth path from points using Bezier curves
  */
-fun createSmoothPath(points: List<Offset>): Path {
-    val path = Path()
-    if (points.isEmpty()) {
-        Log.d(TAG, "createSmoothPath: Empty points list")
-        return path
-    }
-    if (points.size == 1) {
-        Log.d(TAG, "createSmoothPath: Single point, creating minimal line")
-        path.moveTo(points[0].x, points[0].y)
-        path.lineTo(points[0].x, points[0].y + 0.1f)
-        return path
-    }
-
-    path.moveTo(points[0].x, points[0].y)
-    if (points.size == 2) {
-        Log.d(TAG, "createSmoothPath: Two points, creating direct line")
-        path.lineTo(points[1].x, points[1].y)
-    } else {
-        Log.v(TAG, "createSmoothPath: ${points.size} points, creating smooth path with bezier curves")
-        for (i in 1 until points.size) {
-            if (i < points.size - 1) {
-                val xc = (points[i].x + points[i + 1].x) / 2
-                val yc = (points[i].y + points[i + 1].y) / 2
-                path.quadraticBezierTo(points[i].x, points[i].y, xc, yc)
-            } else {
-                path.lineTo(points[i].x, points[i].y)
-            }
-        }
-    }
-    return path
-}
+fun createSmoothPath(points: List<Offset>): Path = DrawingUtils.smoothPath(points)

--- a/app/src/main/java/com/example/scribbledash/features/drawscreen/presentation/DrawScreenPreview.kt
+++ b/app/src/main/java/com/example/scribbledash/features/drawscreen/presentation/DrawScreenPreview.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
-import com.example.scribbledash.features.drawscreen.presentation.components.createSmoothPath
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex

--- a/app/src/main/java/com/example/scribbledash/features/drawscreen/presentation/DrawScreenResult.kt
+++ b/app/src/main/java/com/example/scribbledash/features/drawscreen/presentation/DrawScreenResult.kt
@@ -45,7 +45,6 @@ import coil.decode.SvgDecoder
 import coil.request.ImageRequest
 import com.example.scribbledash.R
 import com.example.scribbledash.features.drawscreen.presentation.components.DrawingCanvas
-import com.example.scribbledash.features.drawscreen.presentation.components.createSmoothPath
 import com.example.scribbledash.features.drawscreen.presentation.model.StrokeData
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.foundation.layout.*


### PR DESCRIPTION
## Summary
- add `DrawingUtils.smoothPath` for Bézier smoothing
- use this helper in drawing canvas and difficulty comparator
- clean up unused `createSmoothPath` imports

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af04fcda0832896fcb6a75dc3bab1